### PR TITLE
Support payload based otas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/example_builds/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ If on Windows, you can use the [Windows Subsystem for Linux](https://en.wikipedi
 The script should be pretty readable and self-explanatory, without any bash knowledge.
 To sum it up, it downloads the latest LineageOS build on your pc, extracts the `boot` image from the archive, transfers it on your phone, uses the Magisk app installed on your phone to patch the `boot` image, reboots the phone in fastboot mode, then flashes the patched boot image and restarts the device.
 
+## Different methods of extracting the `boot.img` file
+
+There are 3 different methods to extract the `boot.img` file, depending on your particular device. In this [LineageOS wiki article](https://wiki.lineageos.org/extracting_blobs_from_zips) you can find more details on these methods.
+
+This script currently supports extracting from block-based OTAs and from payload-based OTAs. File-based OTAs are not yet supported.
+
 ## Limitations
 
 See the current issues in the issue tracker of this repo.

--- a/reinstall-magisk-on-lineageos
+++ b/reinstall-magisk-on-lineageos
@@ -43,9 +43,29 @@ extract_boot_image_from_file_based_ota() {
     exit 1
 }
 
+install_python_protobuf() {
+    sudo python3 -m pip install protobuf
+}
+
+extract_payload_from_payload_based_ota() {
+    unzip -od /tmp /tmp/lineageos-last-build.zip payload.bin
+}
+
+generate_random_alnum_string_of_length_6() {
+    tr -dc A-Za-z0-9 </dev/urandom | head -c 6
+}
+
+extract_boot_image_from_payload_file() {
+    install_python_protobuf
+    # For cases in which the repo has already been cloned, I prefer to create a random directory name to clone into, instead of deleting any file or directory on the user's machine.
+    scripts_directory_name="scripts_$(generate_random_alnum_string_of_length_6)"
+    git clone https://github.com/LineageOS/scripts /tmp/$scripts_directory_name
+    python /tmp/$scripts_directory_name/update-payload-extractor/extract.py --partitions boot --output_dir /tmp/ /tmp/payload.bin
+}
+
 extract_boot_image_from_payload_based_ota() {
-    echo 'ERROR: the function "extract_boot_image_from_payload_based_ota" is not implemented'
-    exit 1
+    extract_payload_from_payload_based_ota
+    extract_boot_image_from_payload_file
 }
 
 is_ota_payload_based() {

--- a/reinstall-magisk-on-lineageos
+++ b/reinstall-magisk-on-lineageos
@@ -28,6 +28,35 @@ download_latest_lineageos_build() {
 }
 
 extract_boot_image() {
+    # See https://wiki.lineageos.org/extracting_blobs_from_zips to understand the different ways to extract the boot.img file.
+    if is_ota_block_based; then
+        extract_boot_image_from_block_based_ota
+    elif is_ota_payload_based; then
+        extract_boot_image_from_payload_based_ota
+    else
+        extract_boot_image_from_file_based_ota
+    fi
+}
+
+extract_boot_image_from_file_based_ota() {
+    echo 'ERROR: the function "extract_boot_image_from_file_based_ota" is not implemented'
+    exit 1
+}
+
+extract_boot_image_from_payload_based_ota() {
+    echo 'ERROR: the function "extract_boot_image_from_payload_based_ota" is not implemented'
+    exit 1
+}
+
+is_ota_payload_based() {
+    unzip -l /tmp/lineageos-last-build.zip | grep -wq payload.bin
+}
+
+is_ota_block_based() {
+    unzip -l /tmp/lineageos-last-build.zip | grep -wq boot.img
+}
+
+extract_boot_image_from_block_based_ota() {
     unzip -od /tmp /tmp/lineageos-last-build.zip boot.img
 }
 

--- a/test/reinstall-magisk-on-lineageos.bats
+++ b/test/reinstall-magisk-on-lineageos.bats
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 setup() {
     load 'test_helper/bats-support/load'
     load 'test_helper/bats-assert/load'
@@ -8,6 +10,8 @@ test_get_build_url_vayu() { #@test
     load ../reinstall-magisk-on-lineageos
     function get_lineage_version() { echo 18.1-20220527-NIGHTLY-vayu; }
     export -f get_lineage_version
+    function get_device_name() { echo vayu; }
+    export -f get_device_name
     function curl() { cat "$DIR/builds_download_page_vayu.fixture.html"; }
     export -f curl
 
@@ -30,6 +34,8 @@ test_get_build_url_alioth() { #@test
     load ../reinstall-magisk-on-lineageos
     function get_lineage_version() { echo 19.1-20220604-NIGHTLY-alioth; }
     export -f get_lineage_version
+    function get_device_name() { echo alioth; }
+    export -f get_device_name
     function curl() { cat "$DIR/builds_download_page_alioth.fixture.html"; }
     export -f curl
 

--- a/test/reinstall-magisk-on-lineageos.bats
+++ b/test/reinstall-magisk-on-lineageos.bats
@@ -43,3 +43,11 @@ test_get_build_url_alioth() { #@test
 
     assert_output https://mirrorbits.lineageos.org/full/alioth/20220604/lineage-19.1-20220604-nightly-alioth-signed.zip
 }
+
+test_generate_random_alnum_string_of_length_6() { #@test
+    load ../reinstall-magisk-on-lineageos
+
+    run generate_random_alnum_string_of_length_6
+
+    assert_output --regexp '^[0-9a-zA-Z]{6}$'
+}


### PR DESCRIPTION
Add support for payload-based OTAs.

Uses python-protobuf and the LineageOS scripts to extract the boot.img file from the payload.bin file.